### PR TITLE
Fix invalid syntax in downloads.groovy causing breakage during run-app 

### DIFF
--- a/fixtures/downloads.groovy
+++ b/fixtures/downloads.groovy
@@ -20,10 +20,10 @@ fixture {
             releaseDate: new Date(111, 1, 13),
             files: [
                 [ title: "Binary Zip", mirrors: [
-                    new Mirror(name: "grails.org", urlString: "http://grails.org/dist/grails-1.3.8.BUILD-SNAPSHOT.zip")),
-                    new Mirror(name: "Amazon S3", urlString: "http://s3.amazon.com/somebucket/grails-1.3.8.BUILD-SNAPSHOT.zip")) ]],
+                    new Mirror(name: "grails.org", urlString: "http://grails.org/dist/grails-1.3.8.BUILD-SNAPSHOT.zip"),
+                    new Mirror(name: "Amazon S3", urlString: "http://s3.amazon.com/somebucket/grails-1.3.8.BUILD-SNAPSHOT.zip") ]],
                 [ title: "Documentation", mirrors: [
-                    new Mirror(name: "grails.org", urlString: "http://grails.org/dist/grails-docs-1.3.8.BUILD-SNAPSHOT.zip")) ]]])
+                    new Mirror(name: "grails.org", urlString: "http://grails.org/dist/grails-docs-1.3.8.BUILD-SNAPSHOT.zip") ]]])
 
     download137(Download,
             softwareName: "Grails",
@@ -31,10 +31,10 @@ fixture {
             releaseDate: new Date(111, 0, 13),
             files: [
                 [ title: "Binary Zip", mirrors: [
-                    new Mirror(name: "grails.org", urlString: "http://grails.org/dist/grails-1.3.7.zip")),
-                    new Mirror(name: "Amazon S3", urlString: "http://s3.amazon.com/somebucket/grails-1.3.7.zip")) ]],
+                    new Mirror(name: "grails.org", urlString: "http://grails.org/dist/grails-1.3.7.zip"),
+                    new Mirror(name: "Amazon S3", urlString: "http://s3.amazon.com/somebucket/grails-1.3.7.zip") ]],
                 [ title: "Documentation", mirrors: [
-                    new Mirror(name: "grails.org", urlString: "http://grails.org/dist/grails-docs-1.3.7.zip")) ]]])
+                    new Mirror(name: "grails.org", urlString: "http://grails.org/dist/grails-docs-1.3.7.zip") ]]])
 
     download125(Download,
             softwareName: "Grails",
@@ -42,10 +42,10 @@ fixture {
             releaseDate: new Date(110, 9, 4),
             files: [
                 [ title: "Binary Zip", mirrors: [
-                    new Mirror(name: "Codehaus", urlString: "http://dist.codehaus.org/grails/grails-1.2.5.zip")) ]],
+                    new Mirror(name: "Codehaus", urlString: "http://dist.codehaus.org/grails/grails-1.2.5.zip") ]],
                 [ title: "Documentation", mirrors: [
-                    new Mirror(name: "Codehaus", urlString: "http://dist.codehaus.org/grails/grails-docs-1.2.5.zip")),
-                    new Mirror(name: "Amazon S3", urlString: "http://s3.amazon.com/somebucket/grails-docs-1.2.5.zip")) ]]])
+                    new Mirror(name: "Codehaus", urlString: "http://dist.codehaus.org/grails/grails-docs-1.2.5.zip"),
+                    new Mirror(name: "Amazon S3", urlString: "http://s3.amazon.com/somebucket/grails-docs-1.2.5.zip") ]]])
 
     firstVersion(VersionOrder, baseVersion: "1.4 milestone", orderIndex: 1)
     secondVersion(VersionOrder, baseVersion: "1.3", orderIndex: 2)


### PR DESCRIPTION
The constructors for Mirrors in downloads.groovy ended with two sets of parentheses, which was causing breakage on run-app, at least while trying to build with 1.3.7. It looks like the only way this could have worked is if for 1.4+ builds, the other definitions were somehow lazy evaluated and not read in.
