### PR TITLE
Add default grails.serverURL for development environment.

### DIFF
--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -48,6 +48,7 @@ environments {
         searchable.compassConnection = "ram://test-index"
     }
     development {
+        grails.serverURL="http://localhost:8080"
         download.versions = ["1.4 beta", "1.3", "1.2"]
     }
 }


### PR DESCRIPTION
Add default grails.serverURL for development environments, as run-app breaks without it.

The breakage when grails.serverURL isn't present is rather obscure, stating "ConfigObject cannot be cast to string...". If you haven't seen this before, it's unlikely you'll know how to fix it. The development environment is probably almost always localhost:8080 for a new checkout, and this makes it a little easier to start a server for the first time. Anyone who knows to change grails.serverURL still can. This default isn't dissimilar to the default mysql datasource - it's just an easy configuration to get you going.
