### PR TITLE
Plugin search improvements

### DIFF
--- a/grails-app/domain/org/grails/plugin/Plugin.groovy
+++ b/grails-app/domain/org/grails/plugin/Plugin.groovy
@@ -60,6 +60,7 @@ class Plugin implements Taggable, Commentable, Rateable {
             'installation','description','faq','screenshots', 'tags',
             'featured', 'official', 'organization'
         ]
+        title boost: 2.0
         description component: true
         installation component: true
         faq component: true

--- a/grails-app/views/plugin/_searchBar.gsp
+++ b/grails-app/views/plugin/_searchBar.gsp
@@ -1,5 +1,5 @@
 <div class="searchBox">
-    <g:form name="pluginSearch" action="search">
+    <g:form name="pluginSearch" action="search" method="GET">
         <input class="searchInput" type="text" name="q" value="${q?.encodeAsHTML()}"/>
         <input class="searchButton" type="image" src="${resource(dir:'images/new/plugins/Buttons', file:'search_btn.png')}" value="Search"/>
         or <g:link action="browseTags">browse tags</g:link>


### PR DESCRIPTION
A couple of changes to plugin search:

1) When I search for the "mail" plugin on the site, the actual mail plugin ranks very low in the result. So I have boosted the title field in Plugin class so that titles should have more value in search ranking.

2) Changed the plugin search form HTTP method to GET, as it is more apt in the case of search.
