### PR TITLE
Plugins search results wrong last updated value

### DIFF
--- a/grails-app/domain/org/grails/plugin/Plugin.groovy
+++ b/grails-app/domain/org/grails/plugin/Plugin.groovy
@@ -89,6 +89,7 @@ class Plugin implements Taggable, Rateable {
         issuesUrl index: "no", store: "yes"
         avgRating index: "not_analyzed", store: "yes"
         ratingCount index: "not_analyzed", store: "yes"
+        lastReleased index: "no", store: "yes"
         tags component: true
     }
 


### PR DESCRIPTION
Mapping lastReleased so when search results are returned it's not null, fixes issue #16
