### PR TITLE
replaced release date with ISO format

### DIFF
--- a/grails-app/views/download/index.gsp
+++ b/grails-app/views/download/index.gsp
@@ -19,7 +19,7 @@
                         <g:each var="download" in="${groupedDownloads[majorVersion]}">
                             <tr>
                                 <td>${download.download.softwareVersion}</td>
-                                <td class="span2 align-center"><g:formatDate date="${download.download?.releaseDate?.toDate()}" format="y/MM/d" /></td>
+                                <td class="span2 align-center"><g:formatDate date="${download.download?.releaseDate?.toDate()}" format="yyyy-MM-dd" /></td>
                                 <td class="span2 align-center"><a href="${download.download?.releaseNotes}">Release Notes</a></td>
                                 <td class="span2 align-center"><a href="${download.binary[0].mirrors[0].urlString}">Binary</a></td>
                                 <td class="span2 align-center">


### PR DESCRIPTION
Current release date (for example "13/02/25", page http://grails.org/download) absolutely unclear for me - what is year/month/day. Pls replace it with ISO format - http://en.wikipedia.org/wiki/ISO_week_date

I have made changes but it's not tested
