### PR TITLE
HTML Escape User Input For Searches

### DIFF
--- a/grails-app/views/searchable/index.gsp
+++ b/grails-app/views/searchable/index.gsp
@@ -23,7 +23,7 @@ $(document).ready(function() {
             <span>
                 <g:if test="${haveQuery && resultCount}">
                     Showing <strong>${searchResult.offset + 1}</strong> - <strong>${resultCount + searchResult.offset}</strong> of <strong>${searchResult.total}</strong>
-                    results for <strong>${query}</strong>
+                    results for <strong>${query?.encodeAsHTML()}</strong>
                 </g:if>
                 <g:else>
                     &nbsp;
@@ -32,13 +32,13 @@ $(document).ready(function() {
         </div>
 
         <g:if test="${parseException}">
-            <p>Your query - <strong>${query}</strong> - is not valid.</p>
+            <p>Your query - <strong>${query?.encodeAsHTML()}</strong> - is not valid.</p>
         </g:if>
         <g:elseif test="${clauseException}">
-            <p>Your query - <strong>${query}</strong> - cannot be handled, sorry. Be more restrictive with your wildcards, like '*'.</p>
+            <p>Your query - <strong>${query?.encodeAsHTML()}</strong> - cannot be handled, sorry. Be more restrictive with your wildcards, like '*'.</p>
         </g:elseif>
         <g:elseif test="${haveQuery && !resultCount}">
-            <p>Nothing matched your query - <strong>${query}</strong></p>
+            <p>Nothing matched your query - <strong>${query?.encodeAsHTML()}</strong></p>
         </g:elseif>
         <g:elseif test="${resultCount}">
             <div id="results" class="results">


### PR DESCRIPTION
The commit 5fb9416c did JS escaping on the searches, but there is no escaping of HTML which can lead to other types of attacks. For example, one could use this to perform a phishing attack. Try [opening this link](http://www.grails.org/search?q=%3Cstyle%3Ediv%2C+%23footer+{+display%3A+none%3B+}%3C%2Fstyle%3E%3C%2Fsection%3E%3C%2Fdiv%3E%3C%2Fdiv%3E%3Ciframe+height%3D%22800%22+width%3D%221800%22+style%3D%22overflow%3Ahidden%22+src%3D%22http%3A%2F%2Fevil.com%22%3E%3C%2Fiframe%3E) in FireFox:

```
http://www.grails.org/search?q=%3Cstyle%3Ediv%2C+%23footer+{+display%3A+none%3B+}%3C%2Fstyle%3E%3C%2Fsection%3E%3C%2Fdiv%3E%3C%2Fdiv%3E%3Ciframe+height%3D%22800%22+width%3D%221800%22+style%3D%22overflow%3Ahidden%22+src%3D%22http%3A%2F%2Fevil.com%22%3E%3C%2Fiframe%3E
```

Imagine that link was an actual evil site that had a fake login form requesting the users credentials and submitted them to the evil site.

This commit HTML Escapes the query.
