### PR TITLE
Remove extra spaces before colons on all fields on the plugin pages.

### DIFF
--- a/grails-app/views/plugin/_pluginTags.gsp
+++ b/grails-app/views/plugin/_pluginTags.gsp
@@ -1,4 +1,4 @@
-<span>Tags :</span>
+<span>Tags:</span>
 <span id="plugin-tags-${plugin.id}">
     <g:if test="${plugin.tags.size() > 0}">
         <g:each in="${plugin.tags}" var="tag" status="i"><g:if test="${i > 0}">, </g:if><a href="/plugins/tag/${tag}">${tag}</a></g:each>

--- a/grails-app/views/plugin/editPlugin.gsp
+++ b/grails-app/views/plugin/editPlugin.gsp
@@ -35,13 +35,13 @@
                     <li>
                         <g:render template="pluginTags" model="[plugin:plugin]" />
                     </li>
-                    <li>Current release : <strong>${plugin.currentRelease.encodeAsHTML()}</strong> • Grails version : ${plugin.grailsVersion.encodeAsHTML() ?: '*'}</li>
-                    <li>Authors : <%= plugin.authors.collect { it.name.encodeAsHTML() }.join(', ') %></li>
+                    <li>Current release: <strong>${plugin.currentRelease.encodeAsHTML()}</strong> • Grails version: ${plugin.grailsVersion.encodeAsHTML() ?: '*'}</li>
+                    <li>Authors: <%= plugin.authors.collect { it.name.encodeAsHTML() }.join(', ') %></li>
                     <g:if test="${plugin.licenses}">
-                        <li>License : <%= plugin.licenses.collect { '<a href="' + it.url.encodeAsHTML() + '">' + it.name + '</a>' }.join(',') %></li>
+                        <li>License: <%= plugin.licenses.collect { '<a href="' + it.url.encodeAsHTML() + '">' + it.name + '</a>' }.join(',') %></li>
                     </g:if>
                     <g:if test="${plugin.organization}">
-                        <li>Organization :
+                        <li>Organization:
                             <g:if test="${plugin.organizationUrl}">
                                 <a href="${plugin.organizationUrl.encodeAsHTML()}">${plugin.organization.encodeAsHTML()}</a>
                             </g:if>
@@ -69,10 +69,10 @@
             </header>
             <div class="desc">
                 <div class="code">
-                    <strong>Dependency :</strong>
+                    <strong>Dependency:</strong>
                     <pre>${plugin.defaultDependencyScope} "${plugin.dependencyDeclaration.encodeAsHTML()}"</pre>
                     <g:if test="${plugin.customRepositoriesDeclaration}">
-                        <strong>Custom repositories :</strong>
+                        <strong>Custom repositories:</strong>
                         <pre>${plugin.customRepositoriesDeclaration.encodeAsHTML()}</pre>
                     </g:if>
                 </div>

--- a/grails-app/views/plugin/list.gsp
+++ b/grails-app/views/plugin/list.gsp
@@ -70,11 +70,11 @@
                             <g:render template="pluginTags" model="[plugin:plugin]" />
                         </li>
                         <li>
-                            Latest : <strong>${plugin.currentRelease}</strong>                            
+                            Latest: <strong>${plugin.currentRelease}</strong>                            
                         </li>
                         <li>Last Updated: <strong><joda:format pattern="dd MMMMM yyyy" value="${plugin.lastUpdated}" /></strong></li>
                         <li>
-                            Grails version : ${plugin.grailsVersion ?: '*'}
+                            Grails version: ${plugin.grailsVersion ?: '*'}
                         </li>
                     </ul>
 

--- a/grails-app/views/plugin/show.gsp
+++ b/grails-app/views/plugin/show.gsp
@@ -27,20 +27,20 @@
                         <g:render template="pluginTags" model="[plugin:plugin]" />
                     </li>
                     <li>
-                        Latest : <strong>${plugin.currentRelease}</strong>                            
+                        Latest: <strong>${plugin.currentRelease}</strong>                            
                     </li>
                     <li>Last Updated: <strong><joda:format pattern="dd MMMMM yyyy" value="${plugin.lastReleased}" /></strong></li>
                     <li>
-                        Grails version : ${plugin.grailsVersion ?: '*'}
+                        Grails version: ${plugin.grailsVersion ?: '*'}
                     </li>
                 </ul>
                 <ul class="meta">
-                    <li>Authors : <%= plugin.authors.collect { it.name.encodeAsHTML() }.join(', ') %></li>
+                    <li>Authors: <%= plugin.authors.collect { it.name.encodeAsHTML() }.join(', ') %></li>
                     <g:if test="${plugin.licenses}">
-                        <li>License : <%= plugin.licenses.collect { '<a href="' + it.url.encodeAsHTML() + '">' + it.name + '</a>' }.join(',') %></li>
+                        <li>License: <%= plugin.licenses.collect { '<a href="' + it.url.encodeAsHTML() + '">' + it.name + '</a>' }.join(',') %></li>
                     </g:if>
                     <g:if test="${plugin.organization}">
-                        <li>Organization :
+                        <li>Organization:
                             <g:if test="${plugin.organizationUrl}">
                                 <a href="${plugin.organizationUrl.encodeAsHTML()}">${plugin.organization.encodeAsHTML()}</a>
                             </g:if>
@@ -68,10 +68,10 @@
             </header>
             <div class="desc">
                 <div class="code">
-                    <strong>Dependency :</strong>
+                    <strong>Dependency:</strong>
                     <pre>${plugin.defaultDependencyScope} "${plugin.dependencyDeclaration.encodeAsHTML()}"</pre>
                     <g:if test="${plugin.customRepositoriesDeclaration}">
-                        <strong>Custom repositories :</strong>
+                        <strong>Custom repositories:</strong>
                         <pre>${plugin.customRepositoriesDeclaration.encodeAsHTML()}</pre>
                     </g:if>
                 </div>


### PR DESCRIPTION
The extra colon before a space is bad writing style and it makes the fields less legible.
