### PR TITLE
Show username in site header for logged in user

### DIFF
--- a/grails-app/views/layouts/master.gsp
+++ b/grails-app/views/layouts/master.gsp
@@ -47,7 +47,7 @@
             <shiro:isLoggedIn>
                 <li><a href="/logout">Logout</a></li>
                 <li class="spacing">&nbsp;</li>
-                <li class="current-user"><g:link uri="/profile">${user?.email}</g:link></li>
+                <li class="current-user"><g:link uri="/profile"><b>${user?.login}</b> (${user?.email})</g:link></li>
             </shiro:isLoggedIn>
             <shiro:isNotLoggedIn>
                 <li><a href="/login?targetUri=${request.forwardURI}" class="login">Login</a></li>


### PR DESCRIPTION
Users often forget what their username is since they don't log in frequently. Showing the logged in user's username will help people to remember their username.

screenshot:
![image](https://f.cloud.github.com/assets/47234/898291/b045e2d8-fb0a-11e2-8284-3c3b382e5f65.png)
