### PR TITLE
Enable greenmail URL mapping when running in dev and test

### DIFF
--- a/grails-app/conf/UrlMappings.groovy
+++ b/grails-app/conf/UrlMappings.groovy
@@ -2,6 +2,12 @@ import grails.util.Environment
 
 class UrlMappings {
     static mappings = {
+
+        if (Environment.current == Environment.DEVELOPMENT ||
+            Environment.current == Environment.TEST) {
+            '/greenmail'(controller: 'greenmail', action: 'list')
+        }
+
         "/Home?"(controller: "content", action: "homePage")
         "/$id"(controller: "content", action: "index") {
             constraints {


### PR DESCRIPTION
Can't reach /greenmail for manual testing without this URLMapping enabled.
