### PR TITLE
WEBSITE-160, WEBSITE-264 fix RSS feeds for wiki and plugin updates

### DIFF
--- a/grails-app/conf/UrlMappings.groovy
+++ b/grails-app/conf/UrlMappings.groovy
@@ -88,6 +88,7 @@ class UrlMappings {
 
         /* ========================= PLUGINS ======================= */
         "/plugins"(controller: "plugin", action: "list")
+        "/plugins/feed"(controller: "plugin", action: "feed")
         "/plugins/submitPlugin"(controller: "plugin", action: "submitPlugin")
         "/plugins/tag/$tag"(controller: "plugin", action: "list")
         "/plugin/edit/$id"(controller: "plugin", action:"editPlugin")

--- a/grails-app/controllers/org/grails/plugin/PluginController.groovy
+++ b/grails-app/controllers/org/grails/plugin/PluginController.groovy
@@ -241,6 +241,40 @@ Please go to http://www.grails.org${pendingUrl} to discuss this plugin."""
         }
     }
 
+    def feed() {
+
+        def feedOutput = {
+
+            def (top5, total) = pluginService.listRecentlyUpdatedPluginsWithTotal(max: 5)
+            title = "Grails New Plugins Feed"
+            link = "http://grails.org/plugins"
+            description = "New and recently updated Grails Plugins"
+
+            for(item in top5) {
+                entry(item.title) {
+                    link = "http://grails.org/plugin/${item.name.encodeAsURL()}"
+                    author = item.author
+                    publishedDate = item.lastUpdated?.toDate()
+                    item.summary
+                }
+            }
+        }
+
+        withFormat {
+            html {
+                redirect action: "home" //TODO redirect to latest plugins page
+            }
+            rss {
+                render feedType: "rss", feedOutput
+            }
+            atom {
+                render feedType: "atom", feedOutput
+            }
+        }
+
+    }
+
+
     //---- REST API --------------------------------------
 
     /**

--- a/grails-app/views/content/homePage.gsp
+++ b/grails-app/views/content/homePage.gsp
@@ -2,8 +2,13 @@
     <meta content="master" name="layout"/>
     <r:require modules="homepage"/>
 
-    <feed:meta kind="rss" version="2.0" controller="blog" action="feed" params="[format: 'rss']"/>
-    <feed:meta kind="atom" version="1.0" controller="blog" action="feed" params="[format: 'atom']"/>
+    <%-- RSS feeds --%>
+    <link rel="alternate" type="application/rss+xml" title="Wiki Updates RSS 2.0" href="/wiki/latest?format=rss"/>
+    <link rel="alternate" type="application/atom+xml" title="Wiki Updates Atom 1.0" href="/wiki/latest?format=atom"/>
+    <link rel="alternate" type="application/rss+xml" title="Latest Screencasts RSS 2.0" href="/screencast/feed?format=rss"/>
+    <link rel="alternate" type="application/atom+xml" title="Latest Screencasts Atom 1.0" href="/screencast/feed?format=atom"/>
+    <link rel="alternate" type="application/rss+xml" title="Latest Plugins RSS 2.0" href="/plugins/feed?format=rss"/>
+    <link rel="alternate" type="application/atom+xml" title="Latest Plugins Atom 1.0" href="/plugins/feed?format=atom"/>
 
     <script>
 


### PR DESCRIPTION
Fixes related to RSS feeds:
http://jira.grails.org/browse/WEBSITE-264
http://jira.grails.org/browse/WEBSITE-160

also partially addresses WEBSITE-218 by fixing feeds for screencasts, but there's no code for the websites or tutorials feeds (yet)
