### PR TITLE
Dependeny scope of plugins is now editable

### DIFF
--- a/grails-app/controllers/org/grails/plugin/PluginController.groovy
+++ b/grails-app/controllers/org/grails/plugin/PluginController.groovy
@@ -109,7 +109,7 @@ class PluginController {
     def updatePlugin(String id) {
         def plugin = Plugin.findByName(id)
         if(plugin && params['plugin']) {
-            plugin.properties['summary'] = params['plugin']
+            plugin.properties['summary', 'defaultDependencyScope'] = params['plugin']
             if(plugin.save()) {
                 def installation = params['plugin']['installation'] 
                 def description= params['plugin']['description'] 

--- a/grails-app/domain/org/grails/plugin/Plugin.groovy
+++ b/grails-app/domain/org/grails/plugin/Plugin.groovy
@@ -28,6 +28,7 @@ class Plugin implements Taggable, Rateable {
 
     static final DEFAULT_GROUP = "org.grails.plugins"
     static final DEFAULT_SCOPE = "compile"
+    static final DEFAULT_SCOPE_WHITE_LIST = ["compile", "provided", "test", "runtime", "system"]
     static final WIKIS = ['installation','description','faq','screenshots']
     static final VERSION_PATTERN = /^(\d+(?:\.\d+)*)([\.\-\w]*)?$/
 
@@ -121,6 +122,9 @@ class Plugin implements Taggable, Rateable {
         lastReleased nullable:true
         currentRelease blank: false, matches: VERSION_PATTERN
         usage nullable: true
+        defaultDependencyScope validator: {
+            DEFAULT_SCOPE_WHITE_LIST.contains(it)
+        }
     }
 
     static mapping = {

--- a/grails-app/views/plugin/editPlugin.gsp
+++ b/grails-app/views/plugin/editPlugin.gsp
@@ -1,3 +1,4 @@
+<%@ page import="org.grails.plugin.Plugin" %>
 <head>
     <meta content="master" name="layout"/>
     <title>Edit Plugin: ${plugin.title.encodeAsHTML()}</title>
@@ -70,7 +71,7 @@
             <div class="desc">
                 <div class="code">
                     <strong>Dependency:</strong>
-                    <pre>${plugin.defaultDependencyScope} "${plugin.dependencyDeclaration.encodeAsHTML()}"</pre>
+                    <pre>${plugin.defaultDependencyScope.encodeAsHTML()} "${plugin.dependencyDeclaration.encodeAsHTML()}"</pre>
                     <g:if test="${plugin.customRepositoriesDeclaration}">
                         <strong>Custom repositories:</strong>
                         <pre>${plugin.customRepositoriesDeclaration.encodeAsHTML()}</pre>
@@ -101,6 +102,13 @@
                                 <g:hiddenField name="plugin.installation.version" value="${plugin?.installation?.version}"/>
                                 <g:textArea cols="30" rows="20" name="plugin.installation.body"
                                             value="${plugin?.installation.body}" class="codeEditor input-medium"/>
+                            </div>
+                        </div>
+
+                        <h2>Default dependency scope</h2>
+                        <div class="control-group ${hasErrors(bean: plugin.defaultDependencyScope, field: 'body', 'error')}">
+                            <div class="controls">
+                                <g:select name="plugin.defaultDependencyScope" from="${Plugin.DEFAULT_SCOPE_WHITE_LIST}" value="${plugin?.defaultDependencyScope}" />
                             </div>
                         </div>
 

--- a/grails-app/views/plugin/show.gsp
+++ b/grails-app/views/plugin/show.gsp
@@ -69,7 +69,7 @@
             <div class="desc">
                 <div class="code">
                     <strong>Dependency:</strong>
-                    <pre>${plugin.defaultDependencyScope} "${plugin.dependencyDeclaration.encodeAsHTML()}"</pre>
+                    <pre>${plugin.defaultDependencyScope.encodeAsHTML()} "${plugin.dependencyDeclaration.encodeAsHTML()}"</pre>
                     <g:if test="${plugin.customRepositoriesDeclaration}">
                         <strong>Custom repositories:</strong>
                         <pre>${plugin.customRepositoriesDeclaration.encodeAsHTML()}</pre>

--- a/test/unit/org/grails/plugin/PluginTests.groovy
+++ b/test/unit/org/grails/plugin/PluginTests.groovy
@@ -77,4 +77,18 @@ class PluginTests {
 
         assertEquals "fisheyeUrl/grails-kevin", p.fisheye
     }
+
+    // the scope must be whitelisted:
+    void testDefaultDepencyScope() {
+        mockForConstraintsTests(Plugin)
+
+        def plugin = new Plugin()
+        plugin.defaultDependencyScope = "invalid"
+        plugin.validate()
+        assertEquals "validator", plugin.errors["defaultDependencyScope"]
+
+        plugin.defaultDependencyScope = Plugin.DEFAULT_SCOPE_WHITE_LIST.first()
+        plugin.validate()
+        assertNull plugin.errors["defaultDependencyScope"]
+    }
 }


### PR DESCRIPTION
Plugin authors should now be able to edit the dependency scope on the plugin page. I hope that I adhered to the conventions, please let me know if I should change anything.

See [the thread on the mailing list](http://grails.1312388.n4.nabble.com/Publish-rights-for-Twitter-Bootstrap-plugin-td4651249.html) for more information.
