### PR TITLE
Fixed incorrect screencast link

### DIFF
--- a/grails-app/views/screencast/_screencast.gsp
+++ b/grails-app/views/screencast/_screencast.gsp
@@ -26,7 +26,7 @@
     <div class="desc">
         <p><wiki:shorten key="${'screencast_' + screencastInstance.id}" wikiText="${screencastInstance?.description}" length="250"/>
             <g:if test="${screencastInstance?.description?.length() > 250}">
-                <a href="/tutorial/${screencastInstance?.id}">read more</a>
+                <a href="/screencast/${screencastInstance?.id}">(read more)</a>
             </g:if>
         </p>
     </div>


### PR DESCRIPTION
The titles of screencasts linked properly to the screencast page (grails.org/screencast/22, for example), but the "read more" link pointed at tutorials (grails.org/tutorial/22), not screencasts. To replicate this, check out this page:
http://grails.org/screencasts
and check out the difference between the link of the screencast title and the link of the "read more."

My first pull request; please let me know if you need any other info. Cheers!
