### PR TITLE
Fixed pagination for testimonial listing

### DIFF
--- a/grails-app/controllers/org/grails/community/TestimonialController.groovy
+++ b/grails-app/controllers/org/grails/community/TestimonialController.groovy
@@ -10,9 +10,9 @@ class TestimonialController {
 
     def list = {
         params.max = Math.min(params.max ? params.int('max') : 10, 100)
-
+        def offset = params.int('offset', 0)
         def featuredList =  Testimonial.featuredApproved().list()
-        def nonFeaturedList =  Testimonial.nonFeaturedApproved().list(max: params.max)
+        def nonFeaturedList =  Testimonial.nonFeaturedApproved().list(max: params.max, offset: offset)
         def nonFeaturedTotal = Testimonial.nonFeaturedApproved().count()
 
         [featuredList: featuredList, nonFeaturedList: nonFeaturedList, nonFeaturedTotal: nonFeaturedTotal]


### PR DESCRIPTION
The offset was not handled so the list always shows only the first 10 items.
