### PR TITLE
WEBSITE-284, WEBSITE-286 -  Pagination when searching plugins doesn't work

### DIFF
--- a/grails-app/views/plugin/list.gsp
+++ b/grails-app/views/plugin/list.gsp
@@ -106,7 +106,12 @@
                 if (activeTag) otherParams.tag = activeTag
                 if (activeFilter) otherParams.filter = activeFilter
             %>
-            <g:paginate mapping="pluginList" total="${pluginCount}" max="10" params="${otherParams}" />
+            <g:if test="${actionName == 'search'}">
+                <g:paginate total="${pluginCount}" max="10" params="${otherParams}" />
+            </g:if>
+            <g:else>
+                <g:paginate mapping="pluginList" total="${pluginCount}" max="10" params="${otherParams}" />
+            </g:else>
         </section>
         <r:script>
             tagsInitialized = true


### PR DESCRIPTION
When search action is invoked the pagination still uses the list action for the next page(s) and the search criteria is not picked up by the list action. Could also be solved by changing the controller list action and make it use the q request parameter.
