### PR TITLE
Fixing code mirror in edit plugin

### DIFF
--- a/web-app/css/style.css
+++ b/web-app/css/style.css
@@ -2865,9 +2865,9 @@ a.like.with-ribbon {
   width: 663px;
 }
 .wiki-form .CodeMirror-scroll {
-  height: auto;
-  overflow-y: hidden;
-  overflow-x: auto;
+  height: 200px;
+  overflow-y: auto;
+  overflow-x: hidden;
   width: 100%;
 }
 article.news {


### PR DESCRIPTION
Currently the code mirror editor gets messed up and shows content beyond its bounding box. (In Chrome at least). This resolves that issue by containing the Container-scroll and setting the appropriate overflow attributes.

example of broken: http://bertram.d.pr/Pcty